### PR TITLE
Ajusta senha default de usuário

### DIFF
--- a/src/routes/auth.js
+++ b/src/routes/auth.js
@@ -6,7 +6,7 @@ const users = [
   {
     id: 1,
     username: 'grupo4',
-    password: 'grupo4@1234',
+  password: 'senha@1234',
     attempts: 0,
     blocked: false,
     resetToken: null,


### PR DESCRIPTION
## Summary
- define user password default as `senha@1234` so it matches the docs and tests

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_68815127a01c832c8e76cf25193e6722