### PR TITLE
Add login block test

### DIFF
--- a/test/login.test.js
+++ b/test/login.test.js
@@ -3,11 +3,15 @@ const request = require('supertest');
 const { expect } = require('chai')
 require('dotenv').config()
 const postLogin = require('../fixtures/postLogin.json')
+const { obterToken } = require('../helpers/autenticacao.js')
 
 
 
 describe('Login', () => {
     describe('POST /login', () => {
+        beforeEach(async () => {
+            await obterToken()
+        })
         it('Deve retornar sucesso com 200 quando usar credenciais válidas', async () => {
             const bodyLogin = {...postLogin}
             const response = await request(process.env.BASE_URL)
@@ -30,6 +34,23 @@ describe('Login', () => {
                 .send(bodyLogin)
 
             expect(response.status).to.equal(401);
+        })
+
+        it('Deve bloquear o usuário após 3 tentativas com senha incorreta', async () => {
+            const bodyLogin = {
+                'username': postLogin.username,
+                'password': 'senhaInvalida'
+            }
+
+            let response
+            for (let i = 0; i < 3; i++) {
+                response = await request(process.env.BASE_URL)
+                    .post('/login')
+                    .set('Content-Type', 'application/json')
+                    .send(bodyLogin)
+            }
+
+            expect(response.status).to.equal(423)
         })
 
     })


### PR DESCRIPTION
## Summary
- ensure login tests reset attempts using `obterToken`
- validate that user is blocked after three invalid password attempts

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_6881521adb9c832c98c51b9c52bc7d65